### PR TITLE
Bug fixes and speed up of replay function

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install libgl1-mesa-glx
+          sudo apt upgrade openssl
 
       - name: Build and validate wheel
         run: |
@@ -62,6 +63,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install libgl1-mesa-glx xvfb
+          sudo apt upgrade openssl
 
       - name: Install library
         run: pip install .

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -25,7 +25,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install libgl1-mesa-glx
-          sudo apt upgrade openssl
 
       - name: Build and validate wheel
         run: |
@@ -63,7 +62,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install libgl1-mesa-glx xvfb
-          sudo apt upgrade openssl
 
       - name: Install library
         run: pip install .

--- a/examples/replay.py
+++ b/examples/replay.py
@@ -5,16 +5,11 @@ Replay Decimation
 This example shows how to replay a decimation sequence with replay.
 
 """
-
-
 from time import time
-
 import numpy as np
 import pyvista as pv
 from pyvista import examples
-
 import fast_simplification
-
 
 # Ancillary function to convert triangles to padded faces
 def triangles_to_faces(triangles):

--- a/fast_simplification/Replay.h
+++ b/fast_simplification/Replay.h
@@ -94,6 +94,76 @@ namespace Replay{
             loopj(0,3) vertices[t.v[j]].q =
                 vertices[t.v[j]].q+SymetricMatrix(n.x,n.y,n.z,-n.dot(p[0]));
         }
+
+		// Init Reference ID list
+		loopi(0,vertices.size())
+		{
+			vertices[i].tstart=0;
+			vertices[i].tcount=0;
+		}
+		loopi(0,triangles.size())
+		{
+			Triangle &t=triangles[i];
+			loopj(0,3) vertices[t.v[j]].tcount++;
+		}
+		int tstart=0;
+		loopi(0,vertices.size())
+		{
+			Vertex &v=vertices[i];
+			v.tstart=tstart;
+			tstart+=v.tcount;
+			v.tcount=0;
+		}
+
+		// Write References
+		refs.resize(triangles.size()*3);
+		loopi(0,triangles.size())
+		{
+			Triangle &t=triangles[i];
+			loopj(0,3)
+			{
+				Vertex &v=vertices[t.v[j]];
+				refs[v.tstart+v.tcount].tid=i;
+				refs[v.tstart+v.tcount].tvertex=j;
+				v.tcount++;
+			}
+		}
+
+		// Initialize vertices.borders
+		std::vector<int> vcount,vids;
+
+		loopi(0,vertices.size())
+				vertices[i].border=0;
+
+			loopi(0,vertices.size())
+			{
+				Vertex &v=vertices[i];
+				vcount.clear();
+				vids.clear();
+				loopj(0,v.tcount)
+				{
+					int k=refs[v.tstart+j].tid;
+					Triangle &t=triangles[k];
+					loopk(0,3)
+					{
+						int ofs=0,id=t.v[k];
+						while(ofs<vcount.size())
+						{
+							if(vids[ofs]==id)break;
+							ofs++;
+						}
+						if(ofs==vcount.size())
+						{
+							vcount.push_back(1);
+							vids.push_back(id);
+						}
+						else
+							vcount[ofs]++;
+					}
+				}
+				loopj(0,vcount.size()) if(vcount[j]==1)
+					vertices[vids[j]].border=1;
+			}
 	}
 
 

--- a/fast_simplification/__init__.py
+++ b/fast_simplification/__init__.py
@@ -1,3 +1,3 @@
 from ._version import __version__
-from .replay import replay_simplification
+from .replay import replay_simplification, _map_isolated_points
 from .simplify import simplify, simplify_mesh

--- a/fast_simplification/_replay.pyx
+++ b/fast_simplification/_replay.pyx
@@ -107,13 +107,11 @@ def load_from_vtk(int n_points, float [:, ::1] points, int [::1] faces, int n_fa
     load_points(n_points, &points[0, 0])
 
 
-
 def compute_indice_mapping(int[:, :] collapses, int n_points):
 
     ''' Compute the mapping from original indices to new indices after collapsing
         edges
     '''
-    
     
     # start with identity mapping
     indice_mapping = np.arange(n_points, dtype=int)
@@ -146,37 +144,3 @@ def compute_indice_mapping(int[:, :] collapses, int n_points):
     indice_mapping = np.array(application)[indice_mapping]
 
     return indice_mapping
-
-def compute_new_collapses_from_edges(long [:, :] dec_edges, long [:] isolated_points):
-    ''' Compute the new collapses from the edges of the decimated mesh and the isolated
-        points
-    '''
-
-    cdef long[:, :] new_collapses = np.empty((len(isolated_points), 2), dtype=int)
-    cdef int n_ip = len(isolated_points)
-    cdef int n_edges = len(dec_edges)
-    cdef int i, j
-    cdef long[:] e = np.zeros(2, dtype=int)
-    cdef int found = 0
-
-    for i in range(n_ip):
-        new_collapses[i, 1] = isolated_points[i]
-        new_collapses[i, 0] = -1
-
-    for j in range(n_edges):
-        if found == n_ip:
-            break
-
-        e = dec_edges[j]
-        for i in range(len(isolated_points)):
-            if new_collapses[i, 0] == -1:
-
-                if e[0] == isolated_points[i]:
-                    new_collapses[i, 0] = e[1]
-                    found += 1
-
-                elif e[1] == isolated_points[i]:
-                    new_collapses[i, 0] = e[0]
-                    found += 1
-
-    return np.array(new_collapses)

--- a/fast_simplification/replay.py
+++ b/fast_simplification/replay.py
@@ -182,12 +182,12 @@ def replay_simplification(points, triangles, collapses):
     # Apply the indice mapping to the triangles
     mapped_triangles = indice_mapping[triangles.copy()]
 
-    # Extract the edges and the triangles
-    # Edges can be repeated, but this is not a problem
-    # and it is faster to do so
+    # Extract the edges and the triangles
+    # Edges can be repeated, but this is not a problem
+    # and it is faster to do so
     dec_edges, dec_triangles = _replay.clean_triangles_and_edges(mapped_triangles)
 
-    # Map the isolated points to the triangles
+    # Map the isolated points to the triangles
     mapping, points_to_merge = _map_isolated_points(
         dec_points, dec_edges, dec_triangles
     )

--- a/fast_simplification/replay.py
+++ b/fast_simplification/replay.py
@@ -1,10 +1,6 @@
-from time import time
-
 import numpy as np
-
 from . import _replay
 from .utils import ascontiguous
-
 
 def _map_isolated_points(points, edges, triangles):
     """Map the isolated points to the triangles.
@@ -24,7 +20,7 @@ def _map_isolated_points(points, edges, triangles):
 
     In this example, the points 5, 3, 4, 7, 8, 9 are not connected to any triangle.
     The expected mapping is:
-    
+
     0 -> 0
     1 -> 1
     2 -> 2
@@ -56,10 +52,9 @@ def _map_isolated_points(points, edges, triangles):
         np.ndarray
             merged points array
     """
-
     n_points = points.shape[0]
 
-    # The poins to connect are the points that are not in the triangles
+    # The points to connect are the points that are not in the triangles
     # but are in the edges
     points_to_connect = np.intersect1d(
         np.setdiff1d(np.arange(n_points), np.unique(triangles)), np.unique(edges)

--- a/fast_simplification/replay.py
+++ b/fast_simplification/replay.py
@@ -116,6 +116,21 @@ def replay_simplification(points, triangles, collapses):
     # they share an edge
     new_collapses = _replay.compute_new_collapses_from_edges(dec_edges, isolated_points)
 
+    # Check that isolated points are connected to a non-isolated point
+    # If not, find a path to connect them to a non-isolated point
+    for pos, i in enumerate(new_collapses[:, 0]):
+        if i in isolated_points:
+            j = np.where(new_collapses[:, 1] == i)[0][0]
+            count = 0
+            while (new_collapses[j, 0] in isolated_points) and count < len(new_collapses):
+                j = np.where(new_collapses[:, 1] == new_collapses[j, 0])[0][0]
+                count += 1
+
+            if new_collapses[j, 0] in isolated_points:
+                raise ValueError(f"Wasn't able to connect the isolated points {i}")
+            
+            new_collapses[pos, 0] = new_collapses[j, 0]
+
     # Apply the new collapses)
     mapping = np.arange(dec_points.shape[0])
     for e in new_collapses:

--- a/fast_simplification/replay.py
+++ b/fast_simplification/replay.py
@@ -1,9 +1,9 @@
 from time import time
 
 import numpy as np
-from .utils import ascontiguous
 
 from . import _replay
+from .utils import ascontiguous
 
 
 def _map_isolated_points(points, edges, triangles):

--- a/fast_simplification/replay.py
+++ b/fast_simplification/replay.py
@@ -1,6 +1,7 @@
 from . import _replay
 from time import time
 import numpy as np
+from .utils import ascontiguous
 
 
 def _map_isolated_points(points, edges, triangles):
@@ -103,6 +104,7 @@ def _map_isolated_points(points, edges, triangles):
     return mapping, merged_points
 
 
+@ascontiguous
 def replay_simplification(points, triangles, collapses):
     """Replay the decimation of a triangular mesh.
 

--- a/fast_simplification/simplify.py
+++ b/fast_simplification/simplify.py
@@ -1,5 +1,6 @@
 """Simplification library."""
 from . import _simplify
+from .utils import ascontiguous
 
 
 def _check_args(target_reduction, target_count, n_faces):
@@ -23,6 +24,7 @@ def _check_args(target_reduction, target_count, n_faces):
     return int(target_count)
 
 
+@ascontiguous
 def simplify(
     points,
     triangles,

--- a/fast_simplification/utils.py
+++ b/fast_simplification/utils.py
@@ -1,0 +1,25 @@
+"""Utility functions for the fast_simplification package."""
+
+import numpy as np
+
+
+def ascontiguous(func):
+    """A decorator that ensure that all the numpy arrays passed to the function
+    are contiguous in memory and if not, apply np.ascontinguous arrays.
+    """
+
+    def wrapper(*args, **kwargs):
+        args = list(args)
+        for i, arg in enumerate(args):
+            if isinstance(arg, np.ndarray):
+                args[i] = np.ascontiguousarray(arg)
+
+        for key, value in kwargs.items():
+            if isinstance(value, np.ndarray):
+                kwargs[key] = np.ascontiguousarray(value)
+
+        return func(*args, **kwargs)
+
+    # Copy annotations
+    wrapper.__annotations__ = func.__annotations__
+    return wrapper

--- a/tests/test_map_isolated_points.py
+++ b/tests/test_map_isolated_points.py
@@ -1,5 +1,7 @@
 import numpy as np
+
 from fast_simplification import _map_isolated_points as map_isolated_points
+
 
 def test_map_isolated_points():
     # Example 1

--- a/tests/test_map_isolated_points.py
+++ b/tests/test_map_isolated_points.py
@@ -1,0 +1,211 @@
+import fast_simplification
+import numpy as np
+
+from fast_simplification import _map_isolated_points as map_isolated_points
+
+
+def test_map_isolated_points():
+    # Example 1
+    #
+    #      (1)
+    #     / | \
+    #  (0)  |  (2)-3
+    #     \ | /  \
+    #      (4)    6-9
+    #       |
+    #       5     8-7
+
+    points = np.random.rand(10, 3)
+
+    edges = np.array(
+        [
+            [0, 1],
+            [0, 4],
+            [1, 4],
+            [1, 2],
+            [2, 4],
+            [2, 3],
+            [2, 6],
+            [6, 9],
+            [4, 5],
+            [8, 7],
+        ],
+        dtype=np.int64,
+    )
+
+    triangles = np.array(
+        [
+            [0, 1, 4],
+            [1, 2, 4],
+        ],
+        dtype=np.int64,
+    )
+
+    target_mapping = np.array([0, 1, 2, 2, 4, 4, 2, 7, 8, 2], dtype=np.int64)
+
+    target_merged_points = np.array([3, 5, 6, 9], dtype=np.int64)
+
+    mapping, merged_points = map_isolated_points(points, edges, triangles)
+    assert np.allclose(mapping, target_mapping)
+    assert np.allclose(merged_points, target_merged_points)
+
+    # Example 2
+    #
+    # (7)-(8)       3
+    #   \  |
+    #    \ |
+    #     (0)-1-2-9-4-5-6
+
+    points = np.random.rand(10, 3)
+
+    edges = np.array(
+        [
+            [0, 1],
+            [1, 2],
+            [2, 9],
+            [9, 4],
+            [4, 5],
+            [5, 6],
+        ],
+        dtype=np.int64,
+    )
+
+    triangles = np.array(
+        [
+            [0, 7, 8],
+        ]
+    )
+
+    target_mapping = np.array([0, 0, 0, 3, 0, 0, 0, 7, 8, 0], dtype=np.int64)
+
+    target_merged_points = np.array([1, 2, 4, 5, 6, 9], dtype=np.int64)
+
+    mapping, merged_points = map_isolated_points(points, edges, triangles)
+    assert np.allclose(mapping, target_mapping)
+    assert np.allclose(merged_points, target_merged_points)
+
+    # Example 3
+    #
+    # (1)
+    #  | \
+    #  |  \
+    # (2)-(0)-4-6
+    #         | |
+    #         3-5
+
+    points = np.random.rand(7, 3)
+
+    edges = np.array(
+        [[0, 1], [1, 2], [2, 0], [0, 4], [4, 6], [5, 6], [3, 5]], dtype=np.int64
+    )
+
+    triangles = np.array(
+        [
+            [0, 1, 2],
+        ],
+        dtype=np.int64,
+    )
+
+    target_mapping = np.array([0, 1, 2, 0, 0, 0, 0], dtype=np.int64)
+
+    target_merged_points = np.array([3, 4, 5, 6], dtype=np.int64)
+
+    mapping, merged_points = map_isolated_points(points, edges, triangles)
+    assert np.allclose(mapping, target_mapping)
+    assert np.allclose(merged_points, target_merged_points)
+
+    ## Example 4
+    #
+    # (6)           (7)-(8)
+    #  | \           |  /
+    #  |  \          | /
+    # (5)-(0)-1-2-3-(4)
+    #
+    # Here the situation is ambiguous. Does 2 merge into 0 or 4 ?
+    # We consider 2 -> 4 and 2 -> 0 as valid solutions.
+
+    points = np.random.rand(9, 3)
+
+    edges = np.array(
+        [
+            [0, 1],
+            [1, 2],
+            [2, 3],
+            [3, 4],
+        ],
+        dtype=np.int64,
+    )
+
+    triangles = np.array([[0, 5, 6], [4, 7, 8]], dtype=np.int64)
+
+    target_mapping1 = np.array([0, 0, 0, 4, 4, 5, 6, 7, 8], dtype=np.int64)
+
+    target_mapping2 = np.array([0, 0, 4, 4, 4, 5, 6, 7, 8], dtype=np.int64)
+
+    target_merged_points = np.array([1, 2, 3], dtype=np.int64)
+
+    mapping, merged_points = map_isolated_points(points, edges, triangles)
+    assert np.allclose(mapping, target_mapping1) or np.allclose(
+        mapping, target_mapping2
+    )
+    assert np.allclose(merged_points, target_merged_points)
+
+    ## Example 5
+    #
+    # (1)            (7)-(8)-9
+    #  | \            |  /
+    #  |  \           | /
+    # (2)-(3)-0  4-5-(6)
+
+    points = np.random.rand(10, 3)
+    edges = np.array(
+        [
+            [0, 3],
+            [1, 3],
+            [2, 3],
+            [1, 2],
+            [4, 5],
+            [5, 6],
+            [8, 9],
+        ],
+        dtype=np.int64,
+    )
+    triangles = np.array(
+        [
+            [1, 2, 3],
+            [6, 7, 8],
+        ],
+        dtype=np.int64,
+    )
+
+    target_mapping = np.array([3, 1, 2, 3, 6, 6, 6, 7, 8, 8], dtype=np.int64)
+
+    target_merged_points = np.array([0, 4, 5, 9], dtype=np.int64)
+
+    mapping, merged_points = map_isolated_points(points, edges, triangles)
+    assert np.allclose(mapping, target_mapping)
+    assert np.allclose(merged_points, target_merged_points)
+
+    ## Example 6
+    #
+    # 0-1-2
+
+    points = np.random.rand(3, 3)
+
+    edges = np.array(
+        [
+            [0, 1],
+            [1, 2],
+        ],
+        dtype=np.int64,
+    )
+
+    triangles = np.array([[]], dtype=np.int64)
+
+    target_mapping = np.array([0, 1, 2], dtype=np.int64)
+
+    target_merged_points = np.array([], dtype=np.int64)
+
+    mapping, merged_points = map_isolated_points(points, edges, triangles)
+    assert np.allclose(mapping, target_mapping)
+    assert np.allclose(merged_points, target_merged_points)

--- a/tests/test_map_isolated_points.py
+++ b/tests/test_map_isolated_points.py
@@ -1,8 +1,5 @@
 import numpy as np
-
-import fast_simplification
 from fast_simplification import _map_isolated_points as map_isolated_points
-
 
 def test_map_isolated_points():
     # Example 1

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -59,7 +59,7 @@ def test_collapses_trivial():
         replay_faces,
         indice_mapping,
     ) = fast_simplification.replay_simplification(points, faces, collapses)
-    assert np.allclose(points_out, replay_points, atol=np.std(points_out) / 10)
+    assert np.allclose(points_out, replay_points)
     assert np.allclose(faces_out, replay_faces)
 
 
@@ -81,8 +81,7 @@ def test_collapses_sphere(mesh):
         replay_faces,
         indice_mapping,
     ) = fast_simplification.replay_simplification(points, faces, collapses)
-
-    assert np.allclose(points_out, replay_points, atol=np.std(points_out) / 10)
+    assert np.allclose(points_out, replay_points)
     assert np.allclose(faces_out, replay_faces)
 
 
@@ -108,6 +107,5 @@ def test_collapses_louis():
         replay_faces,
         indice_mapping,
     ) = fast_simplification.replay_simplification(points, faces, collapses)
-
-    assert np.allclose(points_out, replay_points, atol=np.std(points_out) / 10)
+    assert np.allclose(points_out, replay_points)
     assert np.allclose(faces_out, replay_faces)

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -94,7 +94,6 @@ skip_no_examples = pytest.mark.skipif(not has_examples, reason="Requires pyvista
 @skip_no_examples
 @skip_no_vtk
 def test_collapses_louis(louis):
-
     points = louis.points
     faces = louis.faces.reshape(-1, 4)[:, 1:]
     reduction = 0.9

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -94,7 +94,6 @@ skip_no_examples = pytest.mark.skipif(not has_examples, reason="Requires pyvista
 @skip_no_examples
 @skip_no_vtk
 def test_collapses_louis(louis):
-    from pyvista import examples
 
     points = louis.points
     faces = louis.faces.reshape(-1, 4)[:, 1:]

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -77,15 +77,19 @@ def test_collapses_sphere(mesh):
     assert np.allclose(points_out, replay_points)
     assert np.allclose(faces_out, replay_faces)
 
+
 try:
     from pyvista import examples
+
     @pytest.fixture
     def louis():
         return examples.download_louis_louvre()
+
     has_examples = True
 except:
     has_examples = False
 skip_no_examples = pytest.mark.skipif(not has_examples, reason="Requires pyvista.examples")
+
 
 @skip_no_examples
 @skip_no_vtk

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -9,7 +9,6 @@ try:
     has_vtk = True
 except ModuleNotFoundError:
     has_vtk = False
-
 skip_no_vtk = pytest.mark.skipif(not has_vtk, reason="Requires VTK")
 
 
@@ -50,9 +49,6 @@ def test_collapses_trivial():
     points_out, faces_out, collapses = fast_simplification.simplify(
         points, faces, 0.5, return_collapses=True
     )
-    n_points_before_simplification = len(points)
-    n_points_after_simplification = len(points_out)
-    n_collapses = len(collapses)
 
     (
         replay_points,
@@ -72,9 +68,6 @@ def test_collapses_sphere(mesh):
     points_out, faces_out, collapses = fast_simplification.simplify(
         points, faces, reduction, return_collapses=True
     )
-    n_points_before_simplification = len(points)
-    n_points_after_simplification = len(points_out)
-    n_collapses = len(collapses)
 
     (
         replay_points,
@@ -84,23 +77,28 @@ def test_collapses_sphere(mesh):
     assert np.allclose(points_out, replay_points)
     assert np.allclose(faces_out, replay_faces)
 
+try:
+    from pyvista import examples
+    @pytest.fixture
+    def louis():
+        return examples.download_louis_louvre()
+    has_examples = True
+except:
+    has_examples = False
+skip_no_examples = pytest.mark.skipif(not has_examples, reason="Requires pyvista.examples")
 
+@skip_no_examples
 @skip_no_vtk
-def test_collapses_louis():
+def test_collapses_louis(louis):
     from pyvista import examples
 
-    mesh = examples.download_louis_louvre()
-
-    points = mesh.points
-    faces = mesh.faces.reshape(-1, 4)[:, 1:]
+    points = louis.points
+    faces = louis.faces.reshape(-1, 4)[:, 1:]
     reduction = 0.9
 
     points_out, faces_out, collapses = fast_simplification.simplify(
         points, faces, reduction, return_collapses=True
     )
-    n_points_before_simplification = len(points)
-    n_points_after_simplification = len(points_out)
-    n_collapses = len(collapses)
 
     (
         replay_points,


### PR DESCRIPTION
Hello,

I discovered some bugs in the previous implementation of the replay features, and fixed it.

Bugs were :
* mapping of indices between points before/after decimation was OK most of the time time but sometimes it failed : I write a function to tackle the issue of mapping points that are connected to the triangle mesh through edges but not involved in any triangle. Functional tests are in tests/test_map_isolated_points.py
* the mesh after replaying simplification wasn't exactly the same as after first simplification (vertices location slightly differed). There were no reason for this behavior and it was indeed an error in my implementation, I forgot to initialize the border attribute to the mesh. Now it is fixed, and test_replay pass with a tighter tolerance when comparing mesh after simplification and replay (indeed with the default tol of np.allclose).

In addition, I've optimized some parts of replay function where my previous implementation was too slow or memory inefficient. The interface didn't change.

It could be great if you can release this new version, I think it is now pretty stable. Perhaps some parts of replay function might be speeded up again, but for my use cases (< 1M vertices) I'm happy with the current running time.