### PR TITLE
(bugfix) remove outliers in replay

### DIFF
--- a/fast_simplification/replay.py
+++ b/fast_simplification/replay.py
@@ -163,9 +163,7 @@ def replay_simplification(points, triangles, collapses):
     if triangles.ndim != 2:
         raise ValueError("``triangles`` array must be 2 dimensional")
     if triangles.shape[1] != 3:
-        raise ValueError(
-            f"Expected ``triangles`` array to be (n, 3), not {triangles.shape}"
-        )
+        raise ValueError(f"Expected ``triangles`` array to be (n, 3), not {triangles.shape}")
 
     if not triangles.flags.c_contiguous:
         triangles = np.ascontiguousarray(triangles)

--- a/tests/test_map_isolated_points.py
+++ b/tests/test_map_isolated_points.py
@@ -94,9 +94,7 @@ def test_map_isolated_points():
 
     points = np.random.rand(7, 3)
 
-    edges = np.array(
-        [[0, 1], [1, 2], [2, 0], [0, 4], [4, 6], [5, 6], [3, 5]], dtype=np.int64
-    )
+    edges = np.array([[0, 1], [1, 2], [2, 0], [0, 4], [4, 6], [5, 6], [3, 5]], dtype=np.int64)
 
     triangles = np.array(
         [
@@ -144,9 +142,7 @@ def test_map_isolated_points():
     target_merged_points = np.array([1, 2, 3], dtype=np.int64)
 
     mapping, merged_points = map_isolated_points(points, edges, triangles)
-    assert np.allclose(mapping, target_mapping1) or np.allclose(
-        mapping, target_mapping2
-    )
+    assert np.allclose(mapping, target_mapping1) or np.allclose(mapping, target_mapping2)
     assert np.allclose(merged_points, target_merged_points)
 
     ## Example 5

--- a/tests/test_map_isolated_points.py
+++ b/tests/test_map_isolated_points.py
@@ -94,7 +94,9 @@ def test_map_isolated_points():
 
     points = np.random.rand(7, 3)
 
-    edges = np.array([[0, 1], [1, 2], [2, 0], [0, 4], [4, 6], [5, 6], [3, 5]], dtype=np.int64)
+    edges = np.array(
+        [[0, 1], [1, 2], [2, 0], [0, 4], [4, 6], [5, 6], [3, 5]], dtype=np.int64
+    )
 
     triangles = np.array(
         [
@@ -142,7 +144,9 @@ def test_map_isolated_points():
     target_merged_points = np.array([1, 2, 3], dtype=np.int64)
 
     mapping, merged_points = map_isolated_points(points, edges, triangles)
-    assert np.allclose(mapping, target_mapping1) or np.allclose(mapping, target_mapping2)
+    assert np.allclose(mapping, target_mapping1) or np.allclose(
+        mapping, target_mapping2
+    )
     assert np.allclose(merged_points, target_merged_points)
 
     ## Example 5

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -92,9 +92,7 @@ try:
     has_examples = True
 except:
     has_examples = False
-skip_no_examples = pytest.mark.skipif(
-    not has_examples, reason="Requires pyvista.examples"
-)
+skip_no_examples = pytest.mark.skipif(not has_examples, reason="Requires pyvista.examples")
 
 
 @skip_no_examples

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -85,10 +85,16 @@ try:
     def louis():
         return examples.download_louis_louvre()
 
+    @pytest.fixture
+    def human():
+        return examples.download_human()
+
     has_examples = True
 except:
     has_examples = False
-skip_no_examples = pytest.mark.skipif(not has_examples, reason="Requires pyvista.examples")
+skip_no_examples = pytest.mark.skipif(
+    not has_examples, reason="Requires pyvista.examples"
+)
 
 
 @skip_no_examples
@@ -96,6 +102,26 @@ skip_no_examples = pytest.mark.skipif(not has_examples, reason="Requires pyvista
 def test_collapses_louis(louis):
     points = louis.points
     faces = louis.faces.reshape(-1, 4)[:, 1:]
+    reduction = 0.9
+
+    points_out, faces_out, collapses = fast_simplification.simplify(
+        points, faces, reduction, return_collapses=True
+    )
+
+    (
+        replay_points,
+        replay_faces,
+        indice_mapping,
+    ) = fast_simplification.replay_simplification(points, faces, collapses)
+    assert np.allclose(points_out, replay_points)
+    assert np.allclose(faces_out, replay_faces)
+
+
+@skip_no_examples
+@skip_no_vtk
+def test_human(human):
+    points = human.points
+    faces = human.faces.reshape(-1, 4)[:, 1:]
     reduction = 0.9
 
     points_out, faces_out, collapses = fast_simplification.simplify(


### PR DESCRIPTION
Hi, just found and fix a small bug : points not connected to any triangles (outliers) were not removed when replaying simplification. I didn't anticipate this could happen, but it does with the mesh `pyvista.examples.human`. I added this example to the tests to make sure that the new version does the job.

Would be great if this new version could be integrated in the next release of fast-simplification.
Thanks,