### PR TITLE
Use windows 2019 runner

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -91,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-2019, macOS-latest]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Attempt to resolve windows testing issue by using 2019 runner.