### PR TITLE
Add support for doubles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.14
+  rev: v0.1.15
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
@@ -44,6 +44,6 @@ repos:
 
 # this validates our github workflow files
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.27.3
+  rev: 0.27.4
   hooks:
     - id: check-github-workflows

--- a/fast_simplification/_simplify.pyx
+++ b/fast_simplification/_simplify.pyx
@@ -12,10 +12,10 @@ from libcpp cimport bool
 
 
 cdef extern from "wrapper.h" namespace "Simplify":
-    void load_arrays_int32(const int, const int, float*, int*)
-    void load_arrays_int64(const int, const int, float*, int64_t*)
+    void load_arrays_int32(const int, const int, double*, int*)
+    void load_arrays_int64(const int, const int, double*, int64_t*)
     void simplify_mesh(int, double aggressiveness, bool verbose)
-    void get_points(float*)
+    void get_points(double*)
     void get_triangles(int*)
     void get_collapses(int*)
     int get_faces_int32(int*)
@@ -27,16 +27,16 @@ cdef extern from "wrapper.h" namespace "Simplify":
     int n_triangles()
     int n_collapses()
     int load_triangles_from_vtk(const int, int*)
-    void load_points(const int, float*)
+    void load_points(const int, double*)
 
 
 
-def load_int32(int n_points, int n_faces, float [:, ::1] points, int [:, ::1] faces):
+def load_int32(int n_points, int n_faces, double [:, ::1] points, int [:, ::1] faces):
     load_arrays_int32(n_points, n_faces, &points[0, 0], &faces[0, 0])
 
 
 def load_int64(
-        int n_points, int n_faces, float [:, ::1] points, int64_t [:, ::1] faces
+        int n_points, int n_faces, double [:, ::1] points, int64_t [:, ::1] faces
 ):
     load_arrays_int64(n_points, n_faces, &points[0, 0], &faces[0, 0])
 
@@ -59,7 +59,7 @@ def read(filename):
 
 
 def return_points():
-    cdef float [:, ::1] points = np.empty((n_points(), 3), np.float32)
+    cdef double [:, ::1] points = np.empty((n_points(), 3), np.float64)
     get_points(&points[0, 0])
     return np.array(points)
 
@@ -96,7 +96,7 @@ def return_faces_int64():
     return np.array(faces[:n_tri*4])
 
 
-def load_from_vtk(int n_points, float [:, ::1] points, int [::1] faces, int n_faces):
+def load_from_vtk(int n_points, double [:, ::1] points, int [::1] faces, int n_faces):
     result = load_triangles_from_vtk(n_faces, &faces[0])
     if result:
         raise ValueError(

--- a/fast_simplification/simplify.py
+++ b/fast_simplification/simplify.py
@@ -1,4 +1,6 @@
 """Simplification library."""
+import numpy as np
+
 from . import _simplify
 from .utils import ascontiguous
 
@@ -38,14 +40,12 @@ def simplify(
 
     Parameters
     ----------
-    points : sequence
+    points : sequence[float | double]
         A ``(n, 3)`` array of points. May be a ``numpy.ndarray`` or a
-        list of points. For efficiency, provide points as a float32
-        array.
+        sequence of points. Internally converted to double precision.
     triangles : sequence
         A ``(n, 3)`` array of triangle indices. May be a
-        ``numpy.ndarray`` or a list of triangle indices. For
-        efficiency, provide points as a float32 array.
+        ``numpy.ndarray`` or a list of triangle indices.
     target_reduction : float, optional
         Fraction of the original mesh to remove.  If set to ``0.9``,
         this function will try to reduce the data set to 10% of its
@@ -110,10 +110,9 @@ def simplify(
 
 
     """
-    import numpy as np
-
     if not isinstance(points, np.ndarray):
-        points = np.array(points, dtype=np.float32)
+        points = np.array(points, dtype=np.float64)
+    points = points.astype(np.float64, copy=False)
     if not isinstance(triangles, np.ndarray):
         triangles = np.array(triangles, dtype=np.int32)
 
@@ -154,8 +153,7 @@ def simplify(
 
     if return_collapses:
         return points, faces, _simplify.return_collapses()
-    else:
-        return points, faces
+    return points, faces
 
 
 def simplify_mesh(mesh, target_reduction=None, target_count=None, agg=7, verbose=False):
@@ -207,7 +205,7 @@ def simplify_mesh(mesh, target_reduction=None, target_count=None, agg=7, verbose
     n_faces = mesh.n_faces
     _simplify.load_from_vtk(
         mesh.n_points,
-        mesh.points.astype(np.float32, copy=False),
+        mesh.points.astype(np.float64, copy=False),
         mesh.faces.astype(np.int32, copy=False),
         n_faces,
     )

--- a/fast_simplification/wrapper.h
+++ b/fast_simplification/wrapper.h
@@ -4,7 +4,7 @@
 namespace Simplify{
 
   // load triangles
-  void load_points(const int n_points, float* points){
+  void load_points(const int n_points, double* points){
     vertices.clear();
     // load vertices
     for (int ii = 0; ii < n_points; ii ++){
@@ -63,13 +63,13 @@ namespace Simplify{
   }
 
   void load_arrays_int32(const int n_points, const int n_tri,
-                         float* points, int* faces){
+                         double* points, int* faces){
     load_points(n_points, points);
     load_triangles(n_tri, faces);
   }
 
   void load_arrays_int64(const int n_points, const int n_tri,
-                         float* points, int64_t* faces){
+                         double* points, int64_t* faces){
     load_points(n_points, points);
     load_triangles_int64(n_tri, faces);
   }
@@ -101,7 +101,7 @@ namespace Simplify{
   }
 
   // populate a contiguous array with the points in the vertices vector
-  void get_points(float* points){
+  void get_points(double* points){
 
     // load vertices
     int n_points = vertices.size();


### PR DESCRIPTION
Internally, the C fast simplification library works with doubles, but the wrapper converts to floats. This is inefficient and leads to a loss of information.

Resolve #23 by converting the input points to double precision.
