### PR TITLE
Apply a fix for strange pits and bumps in certain meshes

### DIFF
--- a/fast_simplification/Simplify.h
+++ b/fast_simplification/Simplify.h
@@ -654,7 +654,9 @@ namespace Simplify
 		if( iteration == 0 )
 		{
 			loopi(0,vertices.size())
-			vertices[i].q=SymetricMatrix(0.0);
+				vertices[i].q=SymetricMatrix(0.0);
+			loopi(0,vertices.size())
+				vertices[i].border=0;
 
 			loopi(0,triangles.size())
 			{


### PR DESCRIPTION
Apply the fix from https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification/commit/f958f696c05b4b7a18ca85bc5c89d4f8e60288ad, which fixed https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification/issues/24.

As part of investigating the possibility of adding `python-fast-simplification` package to Fedora, I was trying to determine at what point `Simplify.h` was forked from https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification/. I decided that the answer was https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification/commit/4aeffce360279bd070492487426f3e6715c22562, then I looked at the [changes since then](https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification/commits/master/src.cmd). I’m not sure if any of the other subsequent commits are valuable here and worth cherry-picking, but I thought I would offer up this one since it looked like it fixed a well-defined issue.