### PR TITLE
Use fixed-size cell storage for simplify_mesh output (VTK >= 9.6.2)

### DIFF
--- a/fast_simplification/simplify.py
+++ b/fast_simplification/simplify.py
@@ -224,14 +224,41 @@ def simplify_mesh(
     target_count = _check_args(target_reduction, target_count, n_faces)
     _simplify.simplify(target_count, agg, verbose)
 
-    # return the correct datatype of the faces
-    if pv._get_vtk_id_type() == np.int32:
-        faces = _simplify.return_faces_int32()
-    else:
-        faces = _simplify.return_faces_int64()
+    # Fast simplification only produces triangle meshes, so the output cell
+    # array is uniformly 3-wide.  On VTK >= 9.6.2 this is a perfect fit for
+    # fixed-size cell storage, which drops the redundant offsets array by
+    # storing only the flat connectivity together with a constant cell size.
+    if pv.vtk_version_info >= (9, 6, 2):
+        from vtkmodules.util.numpy_support import numpy_to_vtk
+        from vtkmodules.vtkCommonDataModel import vtkCellArray
 
-    # construct mesh
-    mesh = pv.PolyData(_simplify.return_points(), faces, deep=False)
+        # unpadded flat connectivity (length n_tri * 3), int32.  numpy_to_vtk
+        # maps int32 to a ``vtkTypeInt32Array``, one of the connectivity array
+        # widths accepted by ``vtkCellArray.SetData``.
+        connectivity = _simplify.return_faces_int32_no_padding()
+        connectivity_vtk = numpy_to_vtk(connectivity, deep=False)
+
+        carr = vtkCellArray()
+        carr.SetData(3, connectivity_vtk)
+        # keep the numpy buffer alive for the lifetime of the cell array
+        carr._connectivity_np_ref = connectivity_vtk
+
+        # build an empty PolyData and attach points + polys directly so that
+        # no spurious vertex cells are generated (as would happen when passing
+        # only points to the PolyData constructor)
+        mesh = pv.PolyData()
+        mesh.points = _simplify.return_points()
+        mesh.SetPolys(carr)
+    else:
+        # return the correct datatype of the faces
+        if pv._get_vtk_id_type() == np.int32:
+            faces = _simplify.return_faces_int32()
+        else:
+            faces = _simplify.return_faces_int64()
+
+        # construct mesh
+        mesh = pv.PolyData(_simplify.return_points(), faces, deep=False)
+
     mesh.field_data["fast_simplification_collapses"] = _simplify.return_collapses()
 
     return mesh

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -129,3 +129,25 @@ def test_simplify_mesh(mesh):
     reduction = 0.5
     mesh_out = fast_simplification.simplify_mesh(mesh, reduction)
     assert mesh_out.n_cells == mesh.n_cells * reduction
+
+
+@skip_no_vtk
+def test_simplify_mesh_fixed_size_storage(mesh):
+    reduction = 0.5
+    mesh_out = fast_simplification.simplify_mesh(mesh, reduction)
+
+    # decimated output is uniformly triangular
+    assert mesh_out.n_cells == mesh.n_cells * reduction
+    assert mesh_out.is_all_triangles
+    assert mesh_out.n_verts == 0
+    assert mesh_out.n_lines == 0
+
+    # geometry is correct: reconstruct the triangle connectivity and confirm
+    # it matches the padded-faces path
+    points, faces = fast_simplification.simplify(mesh.points, mesh.regular_faces, reduction)
+    assert np.allclose(mesh_out.points, points)
+    assert np.array_equal(mesh_out.regular_faces, faces)
+
+    # on VTK >= 9.6.2 the polys use fixed-size storage (no explicit offsets)
+    if pv.vtk_version_info >= (9, 6, 2):
+        assert mesh_out.GetPolys().IsStorageFixedSize()


### PR DESCRIPTION
## Summary

`simplify_mesh` always produces a purely triangular mesh, so the output cell array is uniformly 3-wide. When the installed VTK supports fixed-size cell-array storage (>= 9.6.2), we can store just the flat connectivity together with a constant cell size and drop the redundant explicit offsets array.

This builds the output `PolyData` polys via `vtkCellArray.SetData(3, connectivity)` from the already-available unpadded int32 connectivity (`_simplify.return_faces_int32_no_padding()`), yielding a mesh whose `GetPolys().IsStorageFixedSize()` is `True`. For VTK < 9.6.2 the existing padded-faces path is preserved unchanged as a fallback.

Benefits:
- Lower memory: no separate offsets array is materialised for the (uniform) triangle connectivity.
- Parity with the broader pyvista fixed-size cell-array work.

The gate is purely `pv.vtk_version_info >= (9, 6, 2)`; no unreleased pyvista symbols are imported.

## Notes
- The empty-`PolyData` + `.points =` + `SetPolys(...)` idiom is used so no spurious vertex cells are generated (passing only points to the `PolyData` constructor would create per-point verts).
- Geometry is identical to the legacy path (verified points and connectivity match exactly).

## Test
Adds `test_simplify_mesh_fixed_size_storage`, which asserts the output is all-triangles with no vert/line cells, that the geometry round-trips against the array API, and (guarded behind `pv.vtk_version_info >= (9, 6, 2)`) that `GetPolys().IsStorageFixedSize()` is `True`.

## Precedent
Same approach as the sibling `pyvista/pyvista-stl` (and `pyvista-miniply`) fixed-size cell-array changes.

🤖 Generated with Claude Opus 4.8 (Claude Code)
