### PR TITLE
Add preserve_border option to simplify and simplify_mesh (#89)

### DIFF
--- a/fast_simplification/Simplify.h
+++ b/fast_simplification/Simplify.h
@@ -346,7 +346,7 @@ namespace Simplify
 	//                 more iterations yield higher quality
 	//
 
-	void simplify_mesh(int target_count, double agressiveness=7, bool verbose=false)
+	void simplify_mesh(int target_count, double agressiveness=7, bool verbose=false, bool preserve_border=false)
 	{
 
 		// init
@@ -403,7 +403,11 @@ namespace Simplify
 					int i0=t.v[ j     ]; Vertex &v0 = vertices[i0];
 					int i1=t.v[(j+1)%3]; Vertex &v1 = vertices[i1];
 					// Border check
-					if(v0.border != v1.border)  continue;
+					if (preserve_border) {
+						if (v0.border || v1.border) continue;  // keep all open-border vertices
+					} else if (v0.border != v1.border) {
+						continue;  // base behaviour
+					}
 
 					// Compute vertex to collapse to
 					vec3f p;
@@ -458,7 +462,7 @@ namespace Simplify
 
 	} //simplify_mesh()
 
-	void simplify_mesh_lossless(bool verbose=false)
+	void simplify_mesh_lossless(bool verbose=false, bool preserve_border=false)
 	{
 		// init
 		loopi(0,triangles.size()) triangles[i].deleted=0;
@@ -501,7 +505,11 @@ namespace Simplify
 					int i1=t.v[(j+1)%3]; Vertex &v1 = vertices[i1];
 
 					// Border check
-					if(v0.border != v1.border)  continue;
+					if (preserve_border) {
+						if (v0.border || v1.border) continue;  // keep all open-border vertices
+					} else if (v0.border != v1.border) {
+						continue;  // base behaviour
+					}
 
 					// Compute vertex to collapse to
 					vec3f p;

--- a/fast_simplification/_simplify.pyx
+++ b/fast_simplification/_simplify.pyx
@@ -14,8 +14,8 @@ from libcpp cimport bool
 cdef extern from "wrapper.h" namespace "Simplify":
     void load_arrays_int32(const int, const int, double*, int*)
     void load_arrays_int64(const int, const int, double*, int64_t*)
-    void simplify_mesh(int, double aggressiveness, bool verbose)
-    void simplify_mesh_lossless(bool)
+    void simplify_mesh(int, double aggressiveness, bool verbose, bool preserve_border)
+    void simplify_mesh_lossless(bool, bool preserve_border)
     void get_points(double*)
     void get_triangles(int*)
     void get_collapses(int*)
@@ -42,11 +42,11 @@ def load_int64(
     load_arrays_int64(n_points, n_faces, &points[0, 0], &faces[0, 0])
 
 
-def simplify(int target_count, double aggressiveness=7, bool verbose=False):
-    simplify_mesh(target_count, aggressiveness, verbose)
+def simplify(int target_count, double aggressiveness=7, bool verbose=False, bool preserve_border=False):
+    simplify_mesh(target_count, aggressiveness, verbose, preserve_border)
 
-def simplify_lossless(bool verbose=False):
-    simplify_mesh_lossless(verbose)
+def simplify_lossless(bool verbose=False, bool preserve_border=False):
+    simplify_mesh_lossless(verbose, preserve_border)
 
 
 def save_obj(filename):

--- a/fast_simplification/simplify.py
+++ b/fast_simplification/simplify.py
@@ -44,6 +44,7 @@ def simplify(
     verbose: bool = False,
     return_collapses: bool = False,
     lossless: bool = False,
+    preserve_border: bool = False,
 ) -> (
     tuple[NDArray[np.float64], NDArray[np.int64]]
     | tuple[NDArray[np.float64], NDArray[np.int64], NDArray[np.int64]]
@@ -80,6 +81,10 @@ def simplify(
         i-th collapse, the vertex ``i1`` was collapsed into the vertex ``i0``.
     lossless : bool, optional
         If True, simplify the mesh losslessly.
+    preserve_border : bool, default: False
+        If True, preserve the open boundary (border) of the mesh by
+        preventing the collapse of any edge that touches a border vertex.
+        Applies to both the standard and lossless simplification paths.
 
     Returns
     -------
@@ -155,10 +160,10 @@ def simplify(
     )
 
     if lossless:
-        _simplify.simplify_lossless(verbose)
+        _simplify.simplify_lossless(verbose, preserve_border)
     else:
         target_count = _check_args(target_reduction, target_count, n_faces)
-        _simplify.simplify(target_count, agg, verbose)
+        _simplify.simplify(target_count, agg, verbose, preserve_border)
     points = _simplify.return_points()
     faces = _simplify.return_faces_int32_no_padding().reshape(-1, 3)
 
@@ -173,6 +178,7 @@ def simplify_mesh(
     target_count: int | None = None,
     agg: float = 7.0,
     verbose: bool = False,
+    preserve_border: bool = False,
 ):
     """Simplify a pyvista mesh.
 
@@ -196,6 +202,9 @@ def simplify_mesh(
         reach the ``target_reduction`` or ``target_count``.
     verbose : bool, optional
         Enable verbose output when simplifying the mesh.
+    preserve_border : bool, default: False
+        If True, preserve the open boundary (border) of the mesh by
+        preventing the collapse of any edge that touches a border vertex.
 
     Returns
     -------
@@ -222,7 +231,7 @@ def simplify_mesh(
     )
 
     target_count = _check_args(target_reduction, target_count, n_faces)
-    _simplify.simplify(target_count, agg, verbose)
+    _simplify.simplify(target_count, agg, verbose, preserve_border)
 
     # Fast simplification only produces triangle meshes, so the output cell
     # array is uniformly 3-wide.  On VTK >= 9.6.2 this is a perfect fit for

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -151,3 +151,53 @@ def test_simplify_mesh_fixed_size_storage(mesh):
     # on VTK >= 9.6.2 the polys use fixed-size storage (no explicit offsets)
     if pv.vtk_version_info >= (9, 6, 2):
         assert mesh_out.GetPolys().IsStorageFixedSize()
+
+
+def _n_boundary_points(mesh):
+    """Return the number of open-boundary (perimeter) points of a mesh."""
+    edges = mesh.extract_feature_edges(
+        boundary_edges=True,
+        feature_edges=False,
+        manifold_edges=False,
+        non_manifold_edges=False,
+    )
+    return edges.n_points
+
+
+@skip_no_vtk
+def test_preserve_border():
+    # A triangulated flat plane has an open boundary (its perimeter). All of
+    # its points are coplanar, so an aggressive decimation happily collapses
+    # boundary points unless they are explicitly protected.
+    mesh = pv.Plane(i_resolution=20, j_resolution=20).triangulate()
+    n_border_in = _n_boundary_points(mesh)
+    assert n_border_in == 80
+
+    # Standard path: without protection the border is eroded, with protection
+    # it is retained exactly.
+    out_free = fast_simplification.simplify_mesh(
+        mesh, target_reduction=0.9, preserve_border=False
+    )
+    out_kept = fast_simplification.simplify_mesh(
+        mesh, target_reduction=0.9, preserve_border=True
+    )
+    assert _n_boundary_points(out_free) < n_border_in
+    assert _n_boundary_points(out_kept) == n_border_in
+
+    # Lossless path (exposed through the array API): same contract.
+    triangles = mesh._connectivity_array.reshape(-1, 3)
+    p_free, f_free = fast_simplification.simplify(
+        mesh.points, triangles, lossless=True, preserve_border=False
+    )
+    p_kept, f_kept = fast_simplification.simplify(
+        mesh.points, triangles, lossless=True, preserve_border=True
+    )
+
+    def _as_polydata(points, faces):
+        cells = np.hstack(
+            [np.full((faces.shape[0], 1), 3, dtype=np.int64), faces.astype(np.int64)]
+        )
+        return pv.PolyData(points, cells)
+
+    assert _n_boundary_points(_as_polydata(p_free, f_free)) < n_border_in
+    assert _n_boundary_points(_as_polydata(p_kept, f_kept)) == n_border_in

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -175,12 +175,8 @@ def test_preserve_border():
 
     # Standard path: without protection the border is eroded, with protection
     # it is retained exactly.
-    out_free = fast_simplification.simplify_mesh(
-        mesh, target_reduction=0.9, preserve_border=False
-    )
-    out_kept = fast_simplification.simplify_mesh(
-        mesh, target_reduction=0.9, preserve_border=True
-    )
+    out_free = fast_simplification.simplify_mesh(mesh, target_reduction=0.9, preserve_border=False)
+    out_kept = fast_simplification.simplify_mesh(mesh, target_reduction=0.9, preserve_border=True)
     assert _n_boundary_points(out_free) < n_border_in
     assert _n_boundary_points(out_kept) == n_border_in
 
@@ -194,9 +190,7 @@ def test_preserve_border():
     )
 
     def _as_polydata(points, faces):
-        cells = np.hstack(
-            [np.full((faces.shape[0], 1), 3, dtype=np.int64), faces.astype(np.int64)]
-        )
+        cells = np.hstack([np.full((faces.shape[0], 1), 3, dtype=np.int64), faces.astype(np.int64)])
         return pv.PolyData(points, cells)
 
     assert _n_boundary_points(_as_polydata(p_free, f_free)) < n_border_in


### PR DESCRIPTION
## Summary

Adds an optional `preserve_border` flag (default `False`) that preserves the open boundary of a mesh during decimation, addressing #89.

When `preserve_border=True`, any edge that touches an open-border vertex is skipped, so the perimeter of an open mesh is retained exactly instead of being eroded by collapses.

## What changed

The flag is threaded through the whole stack:

- **`fast_simplification/Simplify.h`** — `simplify_mesh` and `simplify_mesh_lossless` each take a new `bool preserve_border=false`. The existing border check is generalized: with `preserve_border` it skips a collapse if *either* endpoint is a border vertex; otherwise it keeps the original `v0.border != v1.border` behaviour.
- **`fast_simplification/_simplify.pyx`** — extern declarations and the `simplify` / `simplify_lossless` wrappers pass the flag through.
- **`fast_simplification/simplify.py`** — `simplify(...)` (array API) and `simplify_mesh(...)` (PyVista API) gain a documented `preserve_border` keyword, threaded through both the standard and lossless branches.

Unlike pyfqmr PR #37 (Kramer84/pyfqmr-Fast-Quadric-Mesh-Reduction#37), which applied border preservation only to the lossless method, this applies it to **both** the standard and lossless paths.

## Test

A new `test_preserve_border` decimates a triangulated `pv.Plane` (80 boundary points) at 90% reduction:

- Standard path: `preserve_border=False` erodes the boundary (80 → 15 points); `preserve_border=True` keeps all 80.
- Lossless path: `preserve_border=False` collapses the boundary (80 → 3 points); `preserve_border=True` keeps all 80.

Full existing suite still passes (12 passed).

Closes #89

🤖 Generated with Claude Opus 4.8 (Claude Code)