### PR TITLE
Fix get_faces_int32 VTK-padded connectivity stride bug

### DIFF
--- a/fast_simplification/wrapper.h
+++ b/fast_simplification/wrapper.h
@@ -142,10 +142,10 @@ namespace Simplify{
     int jj = 0;
     for (int ii = 0; ii < n_tri; ii ++){
       if (!triangles[ii].deleted){
-        tri[0 + 3*jj] = 3;
-        tri[1 + 3*jj] = triangles[ii].v[0];
-        tri[2 + 3*jj] = triangles[ii].v[1];
-        tri[3 + 3*jj] = triangles[ii].v[2];
+        tri[0 + 4*jj] = 3;
+        tri[1 + 4*jj] = triangles[ii].v[0];
+        tri[2 + 4*jj] = triangles[ii].v[1];
+        tri[3 + 4*jj] = triangles[ii].v[2];
         jj += 1;
       }
     }

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -180,6 +180,24 @@ def test_return_faces_no_padding_is_flat_connectivity():
     assert np.array_equal(unpadded.reshape(-1, 3), faces)
 
 
+def test_return_faces_int32_is_vtk_padded():
+    # ``return_faces_int32`` (used by simplify.py on a 32-bit-vtkIdType build,
+    # VTK < 9.6.2) returns VTK-padded connectivity [3, i, j, k] per triangle in
+    # a flat int32 buffer of length n_tri*4. A stride bug in the C++ core used
+    # to write 4 values while advancing by 3, clobbering the next triangle's
+    # leading count and leaving a garbage tail; guard against a regression.
+    fast_simplification.simplify(PLANE_POINTS, PLANE_FACES, target_reduction=0.5)
+    padded = _simplify.return_faces_int32()
+    assert padded.dtype == np.int32
+    assert padded.size % 4 == 0
+    quads = padded.reshape(-1, 4)
+    assert np.all(quads[:, 0] == 3)  # every leading count is 3, no garbage tail
+    unpadded = _simplify.return_faces_int32_no_padding()
+    assert np.array_equal(quads[:, 1:].ravel(), unpadded)
+    # and it agrees with the (correctly strided) int64 accessor
+    assert np.array_equal(padded.astype(np.int64), _simplify.return_faces_int64())
+
+
 def test_return_faces_int64_is_vtk_padded():
     # ``return_faces_int64`` is the path simplify.py uses on the standard
     # 64-bit-vtkIdType build: VTK-padded connectivity [3, i, j, k] per


### PR DESCRIPTION
## Summary

Fixes a latent stride bug in `wrapper.h::get_faces_int32`, the accessor that fills a VTK-padded `[3, v0, v1, v2]` triangle-connectivity buffer.

The loop writes **four** int32 values per triangle but advances the write cursor by only **three**:

```cpp
tri[0 + 3*jj] = 3;
tri[1 + 3*jj] = triangles[ii].v[0];
tri[2 + 3*jj] = triangles[ii].v[1];
tri[3 + 3*jj] = triangles[ii].v[2];   // 3 + 3*jj == 0 + 3*(jj+1): clobbers next triangle's slot 0
```

So each triangle's fourth write lands on the next triangle's leading count, corrupting the connectivity and leaving a garbage tail in the region allocated for `n_tri*4`. The sibling `get_faces_int64` already strides by `4*jj`; this change makes `get_faces_int32` match.

## Why it went unnoticed

`return_faces_int32` is only reached by `simplify_mesh` on a **VTK < 9.6.2 build with a 32-bit `vtkIdType`**. Standard VTK is built with a 64-bit id type (→ the correct `get_faces_int64`), and VTK ≥ 9.6.2 uses the unpadded accessor, so the broken path is rarely exercised.

## Testing

Adds `test_return_faces_int32_is_vtk_padded`, which asserts the `[3, i, j, k]` layout (every leading count is `3`, no garbage tail), agreement with the unpadded accessor, and bit-for-bit agreement with the correctly-strided `int64` accessor. Validated locally against PyVista 0.48.4 / VTK 9.6.2.

🤖 Generated with Claude Opus 4.8 (Claude Code)
