### PR TITLE
Fix IndexError in replay_simplification for meshes with unreferenced vertices (#60)

### DIFF
--- a/fast_simplification/replay.py
+++ b/fast_simplification/replay.py
@@ -167,6 +167,39 @@ def replay_simplification(points, triangles, collapses):
     if not triangles.flags.c_contiguous:
         triangles = np.ascontiguousarray(triangles)
 
+    # Vertices that are not referenced by any triangle are dropped by the
+    # decimation core, but the pure-array bookkeeping below
+    # (``compute_indice_mapping``) retains them and assigns them an index.
+    # That shifts the index of every vertex that follows an unreferenced one,
+    # so ``indice_mapping`` ends up pointing past the end of the decimated
+    # points and ``_map_isolated_points`` / the final remap raise an
+    # ``IndexError`` (issue #60). Strip the unreferenced vertices up front so
+    # the numbering is dense, then re-expand ``indice_mapping`` to the original
+    # vertex count (unreferenced vertices map to ``-1``) before returning.
+    n_points_full = points.shape[0]
+    referenced = np.zeros(n_points_full, dtype=bool)
+    if triangles.size:
+        referenced[np.unique(triangles)] = True
+    unreferenced_present = not referenced.all()
+    if unreferenced_present:
+        kept_vertices = np.flatnonzero(referenced)
+        old_to_new = np.full(n_points_full, -1, dtype=np.int64)
+        old_to_new[kept_vertices] = np.arange(kept_vertices.shape[0])
+        points = np.ascontiguousarray(points[kept_vertices])
+        triangles = np.ascontiguousarray(old_to_new[triangles].astype(triangles.dtype, copy=False))
+        collapses = np.asarray(collapses)
+        if collapses.size:
+            remapped = old_to_new[collapses]
+            # An unreferenced vertex has no incident edge, so it can never be
+            # collapsed; a negative entry here means the collapses do not
+            # belong to this mesh.
+            if (remapped < 0).any():
+                raise ValueError(
+                    "``collapses`` references a vertex that is not part of any "
+                    "triangle; the collapses do not match the provided mesh."
+                )
+            collapses = np.ascontiguousarray(remapped.astype(np.int32, copy=False))
+
     if triangles.dtype == np.int32:
         load = _replay.load_int32
     elif triangles.dtype == np.int64:
@@ -212,5 +245,12 @@ def replay_simplification(points, triangles, collapses):
         mapping[ip:] -= 1
     indice_mapping = mapping[indice_mapping]
     dec_triangles = mapping[dec_triangles]
+
+    # Re-expand the mapping to the original vertex count; vertices that were
+    # unreferenced (and therefore not part of the decimated mesh) map to -1.
+    if unreferenced_present:
+        full_indice_mapping = np.full(n_points_full, -1, dtype=indice_mapping.dtype)
+        full_indice_mapping[kept_vertices] = indice_mapping
+        indice_mapping = full_indice_mapping
 
     return dec_points, dec_triangles, indice_mapping

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -133,3 +133,91 @@ def test_human(human):
     ) = fast_simplification.replay_simplification(points, faces, collapses)
     assert np.allclose(points_out, replay_points)
     assert np.allclose(faces_out, replay_faces)
+
+
+def _triangulated_grid(n):
+    """An ``n x n`` triangulated planar grid (no VTK needed)."""
+    xs, ys = np.meshgrid(np.linspace(0, 1, n), np.linspace(0, 1, n))
+    points = np.c_[xs.ravel(), ys.ravel(), np.zeros(n * n)].astype(np.float64)
+    faces = []
+    for i in range(n - 1):
+        for j in range(n - 1):
+            a = i * n + j
+            b = a + 1
+            c = a + n
+            d = c + 1
+            faces += [[a, b, c], [b, d, c]]
+    return points, np.array(faces, dtype=np.int32)
+
+
+def test_replay_unreferenced_vertices_end():
+    # Issue #60: vertices not referenced by any triangle are dropped by the
+    # decimation core but were retained by the index bookkeeping, producing an
+    # ``indice_mapping`` that pointed past the end of the decimated points and
+    # raised ``IndexError`` in ``_map_isolated_points``. Here the unreferenced
+    # vertices are appended at the END of the array.
+    points, faces = _triangulated_grid(12)
+    n_ref = len(points)
+    isolated = np.array([[9.0, 9.0, 9.0], [8.0, 8.0, 8.0], [7.0, 7.0, 7.0]])
+    points_iso = np.vstack([points, isolated])
+
+    _, _, coll = fast_simplification.simplify(
+        points_iso, faces, target_reduction=0.6, return_collapses=True
+    )
+    # must not raise
+    dp, dt, vmap = fast_simplification.replay_simplification(
+        points_iso.astype(np.float32), faces, coll
+    )
+    # every decimated triangle index is in range
+    assert dt.max() < dp.shape[0]
+    assert vmap.shape[0] == points_iso.shape[0]
+    # the unreferenced vertices are not part of the decimated mesh
+    assert np.all(vmap[n_ref:] == -1)
+    # referenced vertices map inside the decimated point set
+    ref_map = vmap[:n_ref]
+    assert ref_map.max() < dp.shape[0]
+    assert ref_map.min() >= 0
+
+
+def test_replay_unreferenced_vertices_middle_matches_clean():
+    # An unreferenced vertex inserted in the MIDDLE of the index range used to
+    # silently shift the decimated index of every following vertex. The
+    # decimated mesh and the referenced-vertex mapping must be identical to the
+    # same mesh without the isolated vertices.
+    points, faces = _triangulated_grid(12)
+
+    # clean reference result
+    _, _, coll = fast_simplification.simplify(
+        points, faces, target_reduction=0.6, return_collapses=True
+    )
+    dp0, dt0, vm0 = fast_simplification.replay_simplification(
+        points.astype(np.float32), faces, coll
+    )
+
+    # insert isolated vertices in the middle; shift the affected face indices
+    at = 50
+    isolated = np.array([[5.0, 5.0, 5.0], [6.0, 6.0, 6.0], [7.0, 7.0, 7.0]])
+    points_iso = np.insert(points, at, isolated, axis=0)
+    faces_iso = faces.copy()
+    faces_iso[faces_iso >= at] += len(isolated)
+
+    _, _, coll_iso = fast_simplification.simplify(
+        points_iso, faces_iso, target_reduction=0.6, return_collapses=True
+    )
+    dp1, dt1, vm1 = fast_simplification.replay_simplification(
+        points_iso.astype(np.float32), faces_iso, coll_iso
+    )
+
+    # decimated mesh is unchanged by the presence of the isolated vertices
+    assert dp0.shape == dp1.shape and np.allclose(dp0, dp1)
+    assert np.array_equal(dt0, dt1)
+
+    # isolated vertices map to -1
+    assert np.all(vm1[at : at + len(isolated)] == -1)
+
+    # referenced vertices keep the same decimated index (shift-adjusted)
+    def shifted(i):
+        return i + (len(isolated) if i >= at else 0)
+
+    for v in np.unique(faces):
+        assert vm0[v] == vm1[shifted(v)]


### PR DESCRIPTION
## Summary

Fixes #60 — `replay_simplification` raised `IndexError: index N is out of bounds for axis 0 with size N` inside `_map_isolated_points` when the input mesh contained vertices not referenced by any triangle.

## Root cause

The decimation core drops unreferenced vertices, so `_replay.return_points()` never includes them. But the pure-array bookkeeping `compute_indice_mapping` computes ranks over *all* non-collapsed vertices — including the unreferenced ones — and assigns each an index. Because ranks are assigned in ascending original-index order, an unreferenced vertex **shifts the decimated index of every vertex that follows it**. The resulting `indice_mapping` therefore points one-or-more past the end of the decimated point set, and:

- the final `indice_mapping = mapping[indice_mapping]` remap (or, when an unreferenced vertex is touched by a degenerate edge, `_map_isolated_points`) indexes out of bounds → the crash.
- even when it doesn't crash (unreferenced vertex at the very end), the shift **silently corrupts** the mapping for all following vertices.

This is common for meshes carrying UV/texture data (the issue reporter loaded via `trimesh`), which frequently contain unreferenced vertices.

## Fix

Strip unreferenced vertices up front so the vertex numbering is dense, replay on the compacted mesh, then re-expand `indice_mapping` back to the original vertex count with unreferenced vertices mapped to **`-1`** (they are not part of the triangle-only decimated mesh). Collapses are remapped to the compacted numbering; since an unreferenced vertex has no incident edge it can never be a collapse origin, so a negative entry there indicates collapses that don't match the mesh and raises a clear `ValueError`.

Meshes whose vertices are all referenced are untouched (same code path as before).

## Reproducer (before this PR)

```python
import numpy as np, fast_simplification as fs
# triangulated grid + a few UNREFERENCED vertices
pts = np.random.rand(50, 3)                      # 50 unreferenced points ...
grid_pts, faces = ...                            # ... appended to a real grid
points = np.vstack([grid_pts, pts])
_, _, coll = fs.simplify(points, faces, target_reduction=0.75, return_collapses=True)
fs.replay_simplification(points.astype(np.float32), faces, coll)  # -> IndexError
```

## Testing

Two regression tests (offline, no VTK/network): unreferenced vertices **at the end** of the array, and inserted in the **middle** (the silent-shift case) — asserting no crash, that unreferenced vertices map to `-1`, and that the decimated mesh **and** the referenced-vertex mapping are bit-for-bit identical to the same mesh without the isolated vertices. Full suite: 41 tests pass locally (PyVista 0.48.4 / VTK 9.6.2).

🤖 Generated with Claude Opus 4.8 (Claude Code)
