### PR TITLE
Correct simplify return type annotation (int32, not int64)

### DIFF
--- a/fast_simplification/simplify.py
+++ b/fast_simplification/simplify.py
@@ -46,8 +46,8 @@ def simplify(
     lossless: bool = False,
     preserve_border: bool = False,
 ) -> (
-    tuple[NDArray[np.float64], NDArray[np.int64]]
-    | tuple[NDArray[np.float64], NDArray[np.int64], NDArray[np.int64]]
+    tuple[NDArray[np.float64], NDArray[np.int32]]
+    | tuple[NDArray[np.float64], NDArray[np.int32], NDArray[np.int32]]
 ):
     """Simplify a triangular mesh.
 

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -86,6 +86,11 @@ def test_simplify_int64_faces_matches_int32():
     )
     assert np.array_equal(f32, f64)
     assert np.allclose(p32, p64)
+    # ``simplify`` always returns int32 faces regardless of the input face
+    # dtype (it reads back ``return_faces_int32_no_padding``), matching the
+    # return type annotation.
+    assert f32.dtype == np.int32
+    assert f64.dtype == np.int32
 
 
 def test_simplify_list_faces():


### PR DESCRIPTION
## Summary

`fast_simplification.simplify` is annotated as returning `NDArray[np.int64]` faces and collapses, but it **always returns int32**.

## The mismatch

```python
def simplify(...) -> (
    tuple[NDArray[np.float64], NDArray[np.int64]]
    | tuple[NDArray[np.float64], NDArray[np.int64], NDArray[np.int64]]
):
```

The actual returned arrays are:
- **faces**: `_simplify.return_faces_int32_no_padding()` — int32
- **collapses**: `_simplify.return_collapses()` — declared `NDArray<int32_t, 2>` in `_simplify.cpp` — int32

This is independent of the input face dtype: the wrapper dispatches on the input dtype for *loading*, but the results are always read back through the int32 accessors.

### Empirical evidence

Both int32 and int64 face inputs return int32 faces and int32 collapses:

```python
>>> pts, faces = fast_simplification.simplify(P, F.astype(np.int64), target_reduction=0.5)
>>> faces.dtype
dtype('int32')
```

## Changes

- **`fast_simplification/simplify.py`**: the two `NDArray[np.int64]` entries in the `simplify` return annotation (faces and collapses) → `NDArray[np.int32]`. `NDArray[np.float64]` for points is unchanged.
- **`tests/test_bindings.py`**: extended `test_simplify_int64_faces_matches_int32` to assert the returned faces are int32 for both int32 and int64 face inputs.

This is an **annotation-only** change — no runtime behavior and no C++ (`.h`/`.cpp`) is touched.

## Audit of the rest of the package

I audited every `np.int64` occurrence in `fast_simplification/` and deliberately left the following, which are correct:
- **`simplify_mesh`** has no return annotation, and on a 32-bit-vtkIdType build it can legitimately return int64 connectivity via `return_faces_int64()` (gated on `pv._get_vtk_id_type()`), so no annotation is wrong there.
- **`replay.py`**: `replay_simplification` has no type annotations. The `np.int64` uses (`np.arange(..., dtype=np.int64)`, `np.full(..., dtype=np.int64)`) are runtime array constructions, not annotations, and `indice_mapping`/collapses are already handled as int32 at the boundary — no annotation change warranted.
- The `int64` symbols in the C++ wrappers/bindings are the genuine int64 load/accessor paths and are out of scope for an annotation fix.

Only the `simplify` return annotation was actually wrong.

🤖 Generated with Claude Opus 4.8 (Claude Code)