### PR TITLE
Exclude C++ sources and headers from built wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ build-dir = "build/{wheel_tag}"
 minimum-version = "0.10"
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 sdist.exclude = [".github", "*.png", "tests", ".mypy_cache", ".pre-commit-config.yaml", "*_cache", "CONTRIBUTING.md", ".gitignore"]
+wheel.exclude = ["**.cpp", "**.h"]
 
 [tool.setuptools_scm]
 fallback_version = "0.0.0"


### PR DESCRIPTION
These files are not very useful to wheel users, and omitting them saves about 10% of the compressed size of the wheel: not earthshaking, but not nothing.

Before this PR, the `fast_simplification/` package directory in the wheel contains `array_support.h`, `_replay.cpp`, `Replay.h`, `_simplify.cpp`, `Simplify.h`, `wrapper.h`, and `wrapper_replay.h`. After this PR, all of these are absent.